### PR TITLE
Fix `pywin32` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rob-blackbourn/httpx-negotiate-sspi"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pywin32 = "^223"
+pywin32 = ">=223"
 httpx = "> 0.16, < 0.27"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/rob-blackbourn/httpx-negotiate-sspi"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-pypiwin32 = "^223"
+pywin32 = "^223"
 httpx = "> 0.16, < 0.27"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Hi Rob, :wave:
Thanks for making this package available! :heart:

I'm trying to repackage for the `conda-forge` ecosystem and noticed this is using the deprecated `pypiwin32` package instead of the usual [`pywin32`](https://github.com/mhammond/pywin32) version.

`pypiwin32` once solved a packaging problem but is now abandonware which hasn't been published in over 6 years [^1]:

![image](https://github.com/rob-blackbourn/httpx-negotiate-sspi/assets/881019/c520e7e0-55ea-4ab6-8321-d527c3fad135)


[^1]: https://github.com/pypa/pip/pull/11159#issuecomment-1933051895